### PR TITLE
Update `Deprecated API`

### DIFF
--- a/first-non-directory.yazi/README.md
+++ b/first-non-directory.yazi/README.md
@@ -21,6 +21,6 @@ Add this to your `keymap.toml` to set the keymap for the plugin:
 ```toml
 [[manager.prepend_keymap]]
 on   = [ "f", "j" ]
-run  = "plugin --sync first-non-directory"
+run  = "plugin first-non-directory"
 desc = "Jumps to the first file"
 ```

--- a/first-non-directory.yazi/init.lua
+++ b/first-non-directory.yazi/init.lua
@@ -1,3 +1,4 @@
+--- @sync entry
 return {
 	entry = function()
 		local cur = cx.active.current


### PR DESCRIPTION
According to yazi PR [#1891](https://github.com/sxyazi/yazi/pull/1891#issue-2641275285) `--sync` parameter need to be set inside plugin 

The problem mentioned [issue 4](https://github.com/lpanebr/yazi-plugins/issues/4)