### PR TITLE
Fix deprecated ya.mgr_emit()

### DIFF
--- a/first-non-directory.yazi/main.lua
+++ b/first-non-directory.yazi/main.lua
@@ -14,6 +14,6 @@ return {
 		end
 
 		local delta = target_index - cur.cursor
-		ya.manager_emit("arrow", { delta - 1 })
+		ya.emit("arrow", { delta - 1 })
 	end,
 }


### PR DESCRIPTION
ya.mgr_emit() is deprecated since v25.5.28. 

PR: https://github.com/sxyazi/yazi/pull/2653

ya.emit() can be used as a direct replacement for ya.mgr_emit():